### PR TITLE
Add styling for tables

### DIFF
--- a/theme/mkdocs/css/docs.css
+++ b/theme/mkdocs/css/docs.css
@@ -340,6 +340,62 @@ pre {
   font-weight: bold;
 }
 
+/* Tables */
+.content-body table {
+  box-sizing: border-box;
+  margin-bottom: 20px;
+  width: 100%;
+  word-break: normal;
+}
+
+.content-body thead {
+  background-color: #e8e8e8;
+}
+
+.content-body tr {
+  border-top: 1px solid #ccc;
+  vertical-align: top;
+}
+
+.content-body tr:nth-child(2n) {
+  background-color:#f8f8f8;
+}
+
+.content-body th,
+.content-body td
+{
+  padding: 6px 13px;
+}
+
+.content-body td {
+  border: 1px solid #ddd;
+}
+
+.content-body th {
+  background-color: #c0c0c0;
+  border: 1px solid #c0c0c0;
+  text-align: left;
+}
+
+/*
+ * Table used for showing code and CLI output, not using borders
+ * font-styling and background-color is the same as <pre> blocks.
+ */
+.content-body table.code {
+  font-family: Monaco, Consolas, "Lucida Console", monospace;
+  font-size: 11px;
+}
+
+.content-body table.code,
+.content-body table.code tr,
+.content-body table.code th,
+.content-body table.code td
+{
+  background-color: #FCFCFC;
+  border: none;
+  font-weight: normal;
+}
+
 /* Logged-in/out header */
 .topmostnav_loggedin {
   display: none;


### PR DESCRIPTION
This adds some basic styling for tables in the documentation. Styling is based on a mix of GitHub tables and tweaked a bit to match the documentation theme.

With this change inline-styles of existing tables can be removed and html-tables can be replaced with plain MarkDown tables in most cases.

Some examples;

Before:
![remote-libraries-before](https://cloud.githubusercontent.com/assets/1804568/6472023/add5968a-c1ef-11e4-9c20-ea4cc8ea8eee.png)

After:
![remote-libraries-after](https://cloud.githubusercontent.com/assets/1804568/6472029/b6a8de8e-c1ef-11e4-95e3-9719d5753a1f.png)

Plain MarkDown table:
![inline-table](https://cloud.githubusercontent.com/assets/1804568/6472044/cb9ae706-c1ef-11e4-83f4-bb7169116668.png)
