### PR TITLE
Temporarily redirecting to beta site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -205,17 +205,17 @@ theme = "hugo-foundation"
 	name = "Version 1.6"
 	identifier = "smn_sixteen"
 	parent = "mn_versions"
-	url = "http://docs.docker.com/v1.6/"
+	url = "http://beta-docs.docker.io/v1.6/"
 	weight = 1
 [[menu.main]]
 	name = "Version 1.5"
 	identifier = "smn_fifteen"
 	parent = "mn_versions"
-	url = "http://docs.docker.com/v1.5/"
+	url = "http://beta-docs.docker.io/v1.5/"
 	weight = 2
 [[menu.main]]
 	name = "Version 1.4"
 	identifier = "smn_fourteen"
 	parent = "mn_versions"
-	url = "http://docs.docker.com/v1.4/"
+	url = "http://beta-docs.docker.io/v1.4/"
 	weight = 3


### PR DESCRIPTION
* Currently, the docs.docker.com versions are broken as the css and javascript they expect to be located relative to root were removed with the old versions
- This is a temporary fix to the beta site to help users needing to see the old documents

Signed-off-by: Mary Anthony <mary@docker.com>