### PR TITLE
Fix TOC typo in section Administrate Docker

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -87,7 +87,7 @@ theme = "hugo-foundation"
 	parent = "mn_use_docker"
 	weight = 8	
 [[menu.main]]
-	name = "Adminstrate Docker"
+	name = "Administrate Docker"
 	identifier = "smn_administrate"
 	parent = "mn_use_docker"
 	weight = 6	


### PR DESCRIPTION
This is pretty self explanatory. Just fixing a minor typo in the table of contents.