### PR TITLE
Include subversion tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
 		python-dev \
 		python-pip \
 		python-setuptools \
+		subversion-tools\
 		vim-tiny \
 		curl
 


### PR DESCRIPTION
We can use subversion tools to retrieve the contents of the docs subdirectory from our repositories. This allows project repos to build the entire public docs from docs.docker.com.  

Signed-off-by: Mary Anthony <mary@docker.com>