### PR TITLE
Correcting the links after the fix to the old docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -211,17 +211,17 @@ relativeURLs = true
 	name = "Version 1.6"
 	identifier = "smn_sixteen"
 	parent = "mn_versions"
-	url = "http://beta-docs.docker.io/v1.6/"
+	url = "http://docs.docker.com/v1.6/"
 	weight = 1
 [[menu.main]]
 	name = "Version 1.5"
 	identifier = "smn_fifteen"
 	parent = "mn_versions"
-	url = "http://beta-docs.docker.io/v1.5/"
+	url = "http://docs.docker.com/v1.5/"
 	weight = 2
 [[menu.main]]
 	name = "Version 1.4"
 	identifier = "smn_fourteen"
 	parent = "mn_versions"
-	url = "http://beta-docs.docker.io/v1.4/"
+	url = "http://docs.docker.com/v1.4/"
 	weight = 3


### PR DESCRIPTION
Temporarily had the old docs pointed to beta while I fixed things.
All fixed up ready to correct.

Signed-off-by: Mary Anthony <mary@docker.com>