### PR TITLE
Add ssed into the base system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
 		python-setuptools \
 		subversion-tools\
 		vim-tiny \
+		ssed \
 		curl
 
 # Required to publish the documentation.


### PR DESCRIPTION
- supser-sed allows me to use Perl regex and thererfore lookahead in the build scripts


Signed-off-by: Mary Anthony <mary@docker.com>