### PR TITLE
Rename "The Public Hub" to "Docker Hub"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,7 +106,7 @@ relativeURLs = true
 	identifier = "mn_docker_hub"
 	weight = 5
 [[menu.main]]
-	name = "The Public Hub"
+	name = "Docker Hub"
 	identifier = "smn_pubhub"
 	parent = "mn_docker_hub"
 	weight = 1


### PR DESCRIPTION
As discussed in https://github.com/docker/docs-base/pull/131#discussion_r37223038

According to Scott Johnston, VP of Product, "Public Hub" was never vetted nor
approved. It should be changed back to "Docker Hub".

I didn't change the identifier (`smh_pubhub`) because that would involve changes in other repositories, but could be something we want at some point :)