### PR TITLE
Hugo GitHub linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,7 @@ FROM debian:jessie
 MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
 
 RUN apt-get update \
-	&& apt-get install -y \
-		gettext \
-		git \
-		wget \
-		libssl-dev \
-		make \
-		python-dev \
-		python-pip \
-		python-setuptools \
-		subversion-tools\
-		vim-tiny \
-		ssed \
-		curl \
+	&& apt-get install -y gettext git wget libssl-dev make python-dev python-pip python-setuptools subversion-tools vim-tiny ssed curl \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -27,6 +15,7 @@ RUN apt-get update \
 # TODO: Test to see if the above holds true
 RUN pip install awscli==1.4.4 pyopenssl==0.12
 
+# We can go back to using the official version when hugo 0.15 is released with our PR merged.
 #ENV HUGO_VERSION 0.14
 #RUN curl -sSL https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux_amd64.tar.gz \
 #	| tar -v -C /usr/local/bin -xz --strip-components 1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,22 @@ RUN apt-get update \
 # TODO: Test to see if the above holds true
 RUN pip install awscli==1.4.4 pyopenssl==0.12
 
-ENV HUGO_VERSION 0.14
-RUN curl -sSL https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux_amd64.tar.gz \
-	| tar -v -C /usr/local/bin -xz --strip-components 1 \
-	&& mv /usr/local/bin/hugo_${HUGO_VERSION}_linux_amd64 /usr/local/bin/hugo
+#ENV HUGO_VERSION 0.14
+#RUN curl -sSL https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux_amd64.tar.gz \
+#	| tar -v -C /usr/local/bin -xz --strip-components 1 \
+#	&& mv /usr/local/bin/hugo_${HUGO_VERSION}_linux_amd64 /usr/local/bin/hugo
+
+# Using a pre-build of hugo 0.15 a not yet merged patch
+RUN curl -sSL -o /usr/local/bin/hugo https://github.com/docker/hugo/releases/download/test-2/hugo
+RUN chmod 755 /usr/local/bin/hugo
+RUN /usr/local/bin/hugo version
+
+ADD https://github.com/docker/markdownlint/releases/download/v0.1/markdownlint /usr/local/bin/markdownlint
+RUN chmod 755 /usr/local/bin/markdownlint
+
+ADD https://github.com/docker/linkcheck/releases/download/v0.3/linkcheck /usr/local/bin/linkcheck
+RUN chmod 755 /usr/local/bin/linkcheck
+
 
 #######################
 # Copy the content and theme to the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN apt-get update \
 		subversion-tools\
 		vim-tiny \
 		ssed \
-		curl
+		curl \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 
 # Required to publish the documentation.
 # The 1.4.4 version works: the current versions fail in different ways

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ docs-draft: docs-build
 	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 -e DOCKERHOST "$(DOCKER_DOCS_IMAGE)" hugo server --buildDrafts="true" --port=$(DOCSPORT) --baseUrl=$(HUGO_BASE_URL) --bind=$(HUGO_BIND_IP) --config=config.toml
 
 
-docs-shell: docs-build
+docs-shell: docs-build shell
+
+shell:
 	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 "$(DOCKER_DOCS_IMAGE)" bash
 
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docs-base$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 
 
-DOCKER_RUN_DOCS := docker run --rm -it $(DOCS_MOUNT) -e AWS_S3_BUCKET -e NOCACHE
+DOCKER_RUN_DOCS := docker run --rm -it $(DOCS_MOUNT) -e AWS_S3_BUCKET -e NOCACHE --name docker-docs-tools
 
 # for some docs workarounds (see below in "docs-build" target)
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
@@ -37,10 +37,10 @@ GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 default: docs
 
 docs: docs-build
-	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 -e DOCKERHOST "$(DOCKER_DOCS_IMAGE)" hugo server --port=$(DOCSPORT) --baseUrl=$(HUGO_BASE_URL) --bind=$(HUGO_BIND_IP)
+	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 -e DOCKERHOST "$(DOCKER_DOCS_IMAGE)" hugo server --port=$(DOCSPORT) --baseUrl=$(HUGO_BASE_URL) --bind=$(HUGO_BIND_IP) --config=./config.toml
 
 docs-draft: docs-build
-	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 -e DOCKERHOST "$(DOCKER_DOCS_IMAGE)" hugo server --buildDrafts="true" --port=$(DOCSPORT) --baseUrl=$(HUGO_BASE_URL) --bind=$(HUGO_BIND_IP)
+	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 -e DOCKERHOST "$(DOCKER_DOCS_IMAGE)" hugo server --buildDrafts="true" --port=$(DOCSPORT) --baseUrl=$(HUGO_BASE_URL) --bind=$(HUGO_BIND_IP) --config=config.toml
 
 
 docs-shell: docs-build
@@ -58,3 +58,10 @@ leeroy: docs-build
 	# the jenkins task also bind mounts in the current dir into `/src`, so we don't need different Dockerfiles for each repo
 	docker run --rm -t --name docs-pr$BUILD_NUMBER \
 		"$(DOCKER_DOCS_IMAGE)"
+
+markdownlint:
+		docker exec -it docker-docs-tools /usr/local/bin/markdownlint /docs/content/
+
+htmllint:
+		docker exec -it docker-docs-tools /usr/local/bin/linkcheck http://127.0.0.1:8000
+

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@ relativeURLs = true
 [blackfriday]
   fractions = false
   plainIdAnchors = true
+  gitHubLinkEval = true
 
 # Menu configuration should come last in this file;
 # leave at least one blank line at the end

--- a/config.toml
+++ b/config.toml
@@ -134,10 +134,6 @@ relativeURLs = true
 	identifier = "mn_reference"
 	weight = 7
 [[menu.main]]
-	name = "Command line reference"
-	identifier = "smn_cli"
- 	parent = "mn_reference"
-[[menu.main]]
 	name = "Docker Remote API"
 	identifier = "smn_remoteapi"
 	parent = "mn_reference"
@@ -167,28 +163,6 @@ relativeURLs = true
 	identifier = "smn_registry_ref"
 	parent = "mn_reference"
 	weight = 6
-#
-# Open source at Docker
-#
-[[menu.main]]
-	name = "Open Source at Docker"
-	identifier = "mn_opensource"
-	weight = 8
-[[menu.main]]
-	name = "Configure Development Environment"
-	identifier = "smn_develop"
-	parent = "mn_opensource"
-	weight = 2
-[[menu.main]]
-	name = "Contribution Workflow"
-	identifier = "smn_contribute"
-	parent = "mn_opensource"
-	weight = 3
-[[menu.main]]
-	name = "Governance"
-	identifier = "smn_governance"
-	parent = "mn_opensource"
-	weight = 9
 #
 # About
 #
@@ -227,4 +201,3 @@ relativeURLs = true
 	parent = "mn_versions"
 	url = "http://docs.docker.com/v1.4/"
 	weight = 3
-

--- a/content/apidocs.md
+++ b/content/apidocs.md
@@ -1,0 +1,12 @@
++++
+type = "apidocs"
+title = "Generated API documentation"
+description = "Generated API documentation"
+keywords = ["docker, documentation, about, technology, understanding, api, release"]
++++
+
+# Generated API documentation
+
+There is generated API documentation for:
+
+* [Docker Trusted Registry](apidocs/docker-trusted-registry/index.md)

--- a/content/release-notes.md
+++ b/content/release-notes.md
@@ -1,74 +1,24 @@
 +++
 title = "Docker Release Notes"
-description = "Release notes for Docker 1.x."
+description = "Release notes for Docker"
 keywords = ["docker, documentation, about, technology, understanding,  release"]
 [menu.main]
 parent = "mn_about"
 +++
 
 # Release notes
-(2015-08-11)
 
-On August 11, 2015 Docker released Docker Engine (1.8.0) and on August 12, 2015
-(1.8.1). On August 11, 2015 Docker Compose 1.4.0, Docker Swarm 0.4.0, and Docker Machine 0.4.0 to
-the public.
+For information about releases and the features they contain, see the [releases
+feed on the Docker
+Blog](http://blog.docker.com/category/engineering/docker-releases/). For our
+open source projects, you can find detailed information about what changes were
+made in each release in the project changelogs.
 
-### Docker Engine 1.8.3
-(12 October 2015)
-
-As part of our ongoing security efforts, <a href="http://blog.docker.com/2015/10/security-release-docker-1-8-3-1-6-2-cs7"
-target="_blank">a vulnerability was discovered</a> that affects the way content
-is stored and retrieved within the Docker Engine. Today we are releasing a
-security update that fixes this issue. The <a href="https://github.com/docker/docker/blob/master/CHANGELOG.md#183-2015-10-12"
-target="_blank">change log for Docker Engine 1.8.3</a> has a complete list of
-all the changes incorporated into the release.
-
-We recommend that users upgrade to Docker Engine 1.8.3. If you are unable to
-upgrade right away, remember to only pull content from trusted sources.
-
-To keep up to date on all the latest Docker Security news, make sure you review our [Security page](http://www.docker.com/docker-security), subscribe to our
-mailing list, or find us in #docker-security.
-
-## Docker Engine 1.8.0, 1.8.1, 1.8.2
-
-For a complete list of engine patches, fixes, and other improvements, see the
-[release page on GitHub](https://github.com/docker/docker/releases). You can also review the project changelog for details :
-
-* <a href="https://github.com/docker/docker/blob/master/CHANGELOG.md#182-2015-09-10">1.8.2</a>
-* <a href="https://github.com/docker/docker/blob/master/CHANGELOG.md#181-2015-08-12">1.8.1</a>
-* <a href="https://github.com/docker/docker/blob/master/CHANGELOG.md#180-2015-08-11">1.8.0</a>
-
-
-Beginning with this release, Docker Engine maintains an on-going experimental
-build. To learn more about the build and try it for yourself, see [the
-experimental
-directory](https://github.com/docker/docker/tree/master/experimental) in the
-Docker project.
-
-## Docker Swarm 0.4.0
-
-You'll find <a href="https://github.com/docker/swarm/blob/v0.4.0/CHANGELOG.md">
-a changelog in the project repository</a> for a list of changes. You'll find the
-[release for download on
-GitHub](https://github.com/docker/swarm/releases/tag/v0.4.0).
-
-## Docker Compose 1.4.0, 1.4.1, 1.4.2
-
-For a complete list of compose patches, fixes, and other improvements, see <a
-href="https://github.com/docker/compose/blob/master/CHANGELOG.md">the changelog in the project repository</a>. The project also makes a [set of release
-notes](https://github.com/docker/compose/releases) on the project.
-
-
-## Docker Machine 0.4.0
-
-You'll find the [release for download on
-GitHub](https://github.com/docker/machine/releases). This page also includes a
-list of the features provided in the release. For a complete list of machine
-changes, see <a
-href="https://github.com/docker/machine/blob/v0.4.0/CHANGELOG.md"> the changelog
-in the project repository</a>.
-
-Beginning with this release, Docker Machine provides you with a set of
-experimental features to try out.  To learn more about the build and try it for
-yourself, see [the experimental directory in the Docker
-Machine project](https://github.com/docker/machine/tree/master/experimental).
+* <a href="https://github.com/docker/docker/blob/master/CHANGELOG.md"
+target="_blank">Docker Engine</a>
+* <a href="https://github.com/docker/machine/blob/master/CHANGELOG.md"
+target="_blank">Docker Machine</a>
+* <a href="https://github.com/docker/compose/blob/master/CHANGELOG.md"
+target="_blank">Docker Compose</a>
+* <a href="https://github.com/docker/swarm/blob/master/CHANGELOG.md"
+target="_blank">Docker Swarm</a>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">
+    <meta name="keywords" content="{{ with .Keywords }}{{ . }}{{ else }}{{ with .Site.Params.keywords }}{{ . }}{{ end }}{{ end }}">
+    <title>{{.Title }} </title>
+	<link rel="shortcut icon" href="{{ .Site.BaseURL }}images/favicon.png" type="image/png">
+	<link rel="stylesheet" href="{{ .Site.BaseURL  }}dist/assets/css/app.css" />
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/animate.css/3.2.6/animate.min.css">
+	<link rel="stylesheet" href="{{ .Site.BaseURL }}css/custom.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+	<script src="{{ .Site.BaseURL }}dist/assets/js/modernizr.js"></script>
+	<style>.main-footer { margin-top: 36px }</style>
+</head>
+<body>
+  <div class="off-canvas-wrap" data-offcanvas>
+    <div class="inner-wrap">
+
+      <a class="left-off-canvas-toggle" href="#" >
+        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="35px" height="35px" viewBox="0 0 35 35" enable-background="new 0 0 35 35" xml:space="preserve">
+          <path fill="#3597D4" d="M30.583,9.328c0,0.752-0.539,1.362-1.203,1.362H5.113c-0.664,0-1.203-0.61-1.203-1.362l0,0
+          c0-0.752,0.539-1.362,1.203-1.362H29.38C30.045,7.966,30.583,8.576,30.583,9.328L30.583,9.328z"/>
+          <path fill="#3597D4" d="M30.583,17.09c0,0.752-0.539,1.362-1.203,1.362H5.113c-0.664,0-1.203-0.61-1.203-1.362l0,0
+          c0-0.752,0.539-1.362,1.203-1.362H29.38C30.045,15.728,30.583,16.338,30.583,17.09L30.583,17.09z"/>
+          <path fill="#3597D4" d="M30.583,24.387c0,0.752-0.539,1.362-1.203,1.362H5.113c-0.664,0-1.203-0.61-1.203-1.362l0,0
+          c0-0.752,0.539-1.362,1.203-1.362H29.38C30.045,23.025,30.583,23.635,30.583,24.387L30.583,24.387z"/>
+        </svg>
+      </a>
+      <a class="button secondary small get-started-cta">Get Started</a>
+      <header class="main-header">
+        <div class="row">
+          <div class="large-3 columns">
+			  <a href="{{ .Site.BaseURL }}"><img class="logo" src="{{ .Site.BaseURL }}dist/assets/images/logo.png"></a>
+          </div>
+          <div class="large-9 columns">
+            <ul class="nav-global">
+              <li><a href="https://www.docker.com/support">Support</a></li>
+              <li><a href="https://training.docker.com/">Training</a></li>
+              <li><a href="https://docs.docker.com/">Docs</a></li>
+              <li><a href="http://blog.docker.com/">Blog</a></li>
+              <li><a href="https://hub.docker.com/">Docker Hub</a></li>
+              <li><a class="button" href="{{ .Site.BaseURL }}mac/started/">Get Started</a></li>
+            </ul>
+            <ul class="nav-main">
+              <li><a href="https://www.docker.com/products">Products</a>
+                <ul>
+                  <li><a href="https://www.docker.com/pricing">Pricing</a></li>
+                  <li><a href="https://www.docker.com/whatisdocker">What is Docker?</a></li>
+                </ul>
+              </li>
+              <li><a href="https://www.docker.com/customers">Customers</a></li>
+              <li><a href="https://www.docker.com/community">Community</a>
+                <ul>
+                  <li><a href="https://www.docker.com/community/meetups">Meetups</a></li>
+                  <li><a href="https://www.docker.com/community/events">Events</a></li>
+                  <li><a href="https://forums.docker.com">Forums</a></li>
+                  <li><a href="http://www.scoop.it/t/docker-by-docker">Community News</a></li>
+                </ul>
+              </li>
+              <li><a href="https://www.docker.com/partners">Partners</a>
+                <ul>
+                  <li><a href="https://www.docker.com/partners/partner-programs">Partner Programs</a></li>
+                </ul>
+              </li>
+              <li><a href="https://www.docker.com/company">Company</a>
+                <ul>
+                  <li><a href="https://www.docker.com/news-and-press">News &amp; Press</a></li>
+                  <li><a href="https://www.docker.com/work-docker">Work at Docker</a></li>
+                  <li><a href="https://www.docker.com/company/management">Management</a></li>
+                  <li><a href="https://www.docker.com/company/contact">Contact</a></li>
+                </ul>
+              </li>
+              <li><a href="https://www.docker.com/open-source">Open Source</a>
+                <ul>
+                  <li><a href="https://www.docker.com/contribute">Contribute</a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </header>
+
+      <!-- Off Canvas Menu -->
+      <aside class="left-off-canvas-menu">
+        <ul class="off-canvas-list">
+          <li class="has-submenu"><a href="#">Products</a>
+            <ul class="left-submenu">
+              <li class="back"><a href="#">Back</a></li>
+              <li><a href="#">Pricing</a></li>
+              <li><a href="#">What Is Docker</a></li>
+              <li><a href="#">Products</a></li>
+              <li><a href="#">Docker Engine</a></li>
+              <li><a href="#">Docker Hub</a></li>
+              <li><a href="#">Docker Registry</a></li>
+              <li><a href="#">Docker Machine</a></li>
+              <li><a href="#">Docker Swarm</a></li>
+              <li><a href="#">Docker Compose</a></li>
+              <li><a href="#">Kitematic</a></li>
+            </ul>
+          </li>
+          <li><a href="#">Customers</a></li>
+          <li class="has-submenu"><a href="#">Community</a>
+            <ul class="left-submenu">
+              <li class="back"><a href="#">Back</a></li>
+              <li><a href="#">Community</a></li>
+              <li><a href="#">Meetups</a></li>
+              <li><a href="https://www.docker.com/community/events">Events</a></li>
+              <li><a href="#">Forum</a></li>
+              <li><a href="#">Scoop.it</a></li>
+            </ul>
+          </li>
+          <li class="has-submenu"><a href="#">Partners</a>
+            <ul class="left-submenu">
+              <li class="back"><a href="#">Back</a></li>
+              <li><a href="#">Partners</a></li>
+              <li><a href="https://www.docker.com/partners/partner-programs">Partners Programs</a></li>
+            </ul>
+          </li>
+          <li><a href="#">Company</a></li>
+          <li class="has-submenu"><a href="#">Open Source</a>
+            <ul class="left-submenu">
+              <li class="back"><a href="#">Back</a></li>
+              <li><a href="#">Open Source</a></li>
+              <li><a href="#">Contribute</a></li>
+              <li><a href="#">Governance</a></li>
+            </ul>
+          </li>
+        </ul>
+        <ul class="nav-global-off-canvas">
+          <li><a href="#">Support</a></li>
+          <li><a href="#">Training</a></li>
+          <li><a href="#">Docs</a></li>
+          <li><a href="#">Blog</a></li>
+          <li><a href="#">Sign in</a></li>
+          <li><a href="#">Sign up</a></li>
+        </ul>
+      </aside>
+      <!-- close the off-canvas menu -->
+      <a class="exit-off-canvas"></a>
+
+
+
+<div id="docs" class="row">
+    <div class="large-9 columns">
+      <section id="main">
+        <article id="content">
+	  <div>
+		     <h1 id="title">{{ .Title }}</h1>
+			 <span>Sorry, the page you requested is not there.</span>
+	   </div>
+        </article>
+		  </section>
+    </div>
+</div>
+{{ partial "container-footer.html" . }}
+{{ partial "footer.html" . }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -143,12 +143,13 @@
 
 
 <div id="docs" class="row">
-    <div class="large-9 columns">
+    <div class="large-12 columns">
       <section id="main">
         <article id="content">
 	  <div>
-		     <h1 id="title">{{ .Title }}</h1>
-			 <span>Sorry, the page you requested is not there.</span>
+          <h1 style="padding-top:15px;" id="title">{{ .Title }}</h1>
+          <h2 style="color:#3A4E55;">The page you wanted cannot be found or is no longer available.</h2>
+		  <p>Can we help you find what you're looking for? Use the <a href="{{ .Site.BaseURL }}index.html">sitemap to navigate</a> directly or send email to <a href="mailto:docs@docker.com">docs@docker.com</a> for additional help.</p>
 	   </div>
         </article>
 		  </section>

--- a/layouts/apidocs/single.html
+++ b/layouts/apidocs/single.html
@@ -1,0 +1,13 @@
+{{ partial "header.html" . }}
+<div id="docs" class="row">
+    <div class="large-12 columns">
+      <section id="main">
+          <article id="content">
+	          {{ .Content }}
+	      </article>
+      </section>
+	</div>
+</div>
+{{ partial "container-footer.html" . }}
+{{ partial "footer.html" . }}
+

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/animate.css/3.2.6/animate.min.css">
     <link rel="stylesheet" href="/css/custom.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="/dist/assets/js/modernizr.js"></script> 
+    <script src="/dist/assets/js/modernizr.js"></script>
 </head>
 <body>
   <div class="off-canvas-wrap" data-offcanvas>

--- a/validate.sh
+++ b/validate.sh
@@ -1,13 +1,8 @@
 #!/bin/bash  
 set -e
 
-echo "test to check the markdown files start with the Hugo metadata preamble"
-shopt -s globstar
+echo "running markdownlint"
+/usr/local/bin/markdownlint /docs/content/
 
-for f in /docs/content/**/*.md ; do
-  echo "$f"
-  sed '/+++/,/+++/!d' "$f" | grep 'title ='
-done
-
-# make sure Hugo is happy
+echo "running a Hugo build"
 hugo --config=config.toml --log=true --stepAnalysis=true


### PR DESCRIPTION
for the Docker 1.9.0 RC's

This now uses http://github.com/docker/hugo to pull the hugo binary from.