### PR TITLE
Fix the footer position on short pages

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -12,7 +12,6 @@
 	<link rel="stylesheet" href="{{ .Site.BaseURL }}css/custom.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 	<script src="{{ .Site.BaseURL }}dist/assets/js/modernizr.js"></script>
-	<style>.main-footer { margin-top: 36px }</style>
 </head>
 <body>
   <div class="off-canvas-wrap" data-offcanvas>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -63,6 +63,26 @@ div#buildinfo {
   margin-top: 2rem;
 }
 
+.main-footer {
+  width: 100%;
+  height: 250px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+#docs {
+  margin-bottom: 280px;
+}
+
+.off-canvas-wrap {
+  min-height: 100%;
+}
+
+.inner-wrap {
+  position: static;
+}
+
 [data-accordion] [data-content] {
   overflow: hidden;
   max-height: 0;


### PR DESCRIPTION
I've re-purposed this PR.

Fixes the style of any short pages (like the 404 page). Instead of having the footer in the middle of the page, it gets locked to the bottom of the page.

Compare: https://docs.docker.com/engine/userguide/networking/
vs: http://docs-stage.docker.com/engine/userguide/networking/

(assuming no one pushes a different branch to stage).

The footer is placed at the bottom, and doesn't crowd the text.