### PR TITLE
Fixing break in documnetation biuld

### DIFF
--- a/content/test.md
+++ b/content/test.md
@@ -10,9 +10,9 @@ keywords = ["Docker, documentation, manual, guide, reference, api"]
 
 # just test
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent a lorem et urna dictum faucibus. Morbi a nunc consequat neque feugiat commodo. Donec placerat sit amet eros at luctus. Sed non elementum lectus. Nunc lacus neque, dignissim in nunc eu, sollicitudin congue leo. Proin tempus metus ac lacinia viverra. Aenean tortor neque, egestas a nisl tempus, tempus gravida eros. 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent a lorem et urna dictum faucibus. Morbi a nunc consequat neque feugiat commodo. Donec placerat sit amet eros at luctus. Sed non elementum lectus. Nunc lacus neque, dignissim in nunc eu, sollicitudin congue leo. Proin tempus metus ac lacinia viverra. Aenean tortor neque, egestas a nisl tempus, tempus gravida eros.
 
-[blah]({{% thebaseurl %}}test2)
+[blah](test2.md)
 
 ## Heading 2
 
@@ -61,7 +61,7 @@ Vivamus efficitur ipsum id est congue, sed rhoncus neque consectetur. Sed enim a
     docker-engine-1.7.0-1.fc22.src.rpm</a>
         </p>
     </td>
-  </tr> 
+  </tr>
 </table>
 
 
@@ -81,4 +81,3 @@ Vivamus efficitur ipsum id est congue, sed rhoncus neque consectetur. Sed enim a
 ### Heading 3
 
 Vivamus efficitur ipsum id est congue, sed rhoncus neque consectetur. Sed enim ante, mollis ut erat sit amet, semper euismod erat. Donec tincidunt consequat varius. Suspendisse potenti. Nullam blandit pellentesque consectetur. Nulla bibendum turpis tellus, sit amet tristique quam ultrices quis. Nam commodo eleifend lorem, vel suscipit nisl viverra et. Maecenas viverra lobortis nibh ac aliquet.
-


### PR DESCRIPTION
The documentation build is failing because of an issue in docs-base.  This fixes it

Signed-off-by: Mary Anthony <mary@docker.com>

ping @SvenDowideit @thaJeztah 