### PR TITLE
Don't convert double dashes to em-dash

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@ verbose = true
 
 [blackfriday]
   fractions = false
+  smartDashes = false
   plainIdAnchors = true
   sourceRelativeLinksEval = true
 


### PR DESCRIPTION
fixes https://github.com/docker/docs-base/issues/189

but depends on an updated version of our Hugo fork :smile: