### PR TITLE
Second level menus with children styling fix

### DIFF
--- a/layouts/partials/compose-navbar.html
+++ b/layouts/partials/compose-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "compose" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "compose" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "compose" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/dtr-navbar.html
+++ b/layouts/partials/dtr-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "dtr" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "dtr" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "dtr" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/engine-navbar.html
+++ b/layouts/partials/engine-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "engine" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "engine" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "engine" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/hub-navbar.html
+++ b/layouts/partials/hub-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "hub" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "hub" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "hub" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/kitematic-navbar.html
+++ b/layouts/partials/kitematic-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "kitematic" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "kitematic" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "kitematic" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/machine-navbar.html
+++ b/layouts/partials/machine-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "machine" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "machine" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "machine" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/registry-navbar.html
+++ b/layouts/partials/registry-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "registry" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "registry" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "registry" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/layouts/partials/swarm-navbar.html
+++ b/layouts/partials/swarm-navbar.html
@@ -1,6 +1,5 @@
 <aside class="nav-docs">
-  <section id="multiple" class="tutmenu" data-accordion-group>
-    FOOBAR
+  <nav id="multiple" data-accordion-group>
     {{ partial "product-navbar.html" . }}
     {{ $currentNode := . }}
     {{ range .Site.Menus.swarm }}
@@ -15,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "swarm" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -28,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "swarm" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "swarm" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}
@@ -45,5 +50,5 @@
       {{end}}
     </section>
     {{end}}
-  </section>
+  </nav>
 </aside>

--- a/layouts/partials/tutorials-navbar.html
+++ b/layouts/partials/tutorials-navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "tutorials" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "tutorials" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "tutorials" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}

--- a/themes/docker-docs/layouts/partials/navbar.html
+++ b/themes/docker-docs/layouts/partials/navbar.html
@@ -14,12 +14,18 @@
           {{ range .Children }}
           {{if .HasChildren}}
           <article data-accordion>
-            <button data-control>{{ .Pre }} {{ .Name }}</button>
+            <button data-control style="margin-left: .75em;" class="split-button">
+              <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+              <span></span>
+            </button>
             <div data-content>
               {{ range .Children }}
               {{if .HasChildren}}
               <article data-accordion>
-                <button data-control>{{ .Pre }} {{ .Name }}</button>
+                <button data-control class="split-button">
+                  <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
+                  <span></span>
+                </button>
                 <div data-content>
                   {{ range .Children }}
                   <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "main" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
@@ -27,7 +33,7 @@
                 </div>
               </article>
               {{else}}
-              <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent "main" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              <a data-link href="{{ .URL }}" style="margin-left: 1.25em;" class="{{if $currentNode.IsMenuCurrent "main" . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
               {{end}}
 
               {{end}}


### PR DESCRIPTION
@benbridge  This is the fix for the second level menus.  As styled, they weren't actually showing the arrow and the font was incorrect.  I also added a margin to the children via a `style` value on the child.  Maybe not the best way.

Signed-off-by: Mary Anthony <mary@docker.com>