### PR TITLE
The github linking setting changed names when it was merged into hugo master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -sSL -o /usr/local/bin/hugo https://github.com/docker/hugo/releases/dow
 RUN chmod 755 /usr/local/bin/hugo
 RUN /usr/local/bin/hugo version
 
-ADD https://github.com/docker/markdownlint/releases/download/v0.9.3/markdownlint /usr/local/bin/markdownlint
+ADD https://github.com/docker/markdownlint/releases/download/v0.9.4/markdownlint /usr/local/bin/markdownlint
 RUN chmod 755 /usr/local/bin/markdownlint
 
 ADD https://github.com/docker/linkcheck/releases/download/v0.3/linkcheck /usr/local/bin/linkcheck

--- a/config.toml
+++ b/config.toml
@@ -5,13 +5,12 @@ title = "Docker Docs"
 theme = "hugo-foundation"
 canonifyurls = false
 relativeURLs = true
-sourceRelativeLinks = true
 verbose = true
 
 [blackfriday]
   fractions = false
   plainIdAnchors = true
-  gitHubLinkEval = true
+  sourceRelativeLinksEval = true
 
 # Menu configuration should come last in this file;
 # leave at least one blank line at the end


### PR DESCRIPTION
missed it by >||< much.

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>