### PR TITLE
Add hugo-0.16-pre flag for gitHubLinkEval while keeping the existing …

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,8 @@ relativeURLs = true
   fractions = false
   plainIdAnchors = true
   gitHubLinkEval = true
+  sourceRelativeLinksEval = true
+
 
 # Menu configuration should come last in this file;
 # leave at least one blank line at the end


### PR DESCRIPTION
…one for the 1.9.x builds

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

This makes the images and .md links work when working with both the 1.9 builds and the PR builds.