### PR TITLE
Add hugo-0.16-pre flag for gitHubLinkEval while keeping the existing …

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,3 +12,5 @@ verbose = true
   fractions = false
   plainIdAnchors = true
   gitHubLinkEval = true
+  sourceRelativeLinksEval = true
+


### PR DESCRIPTION
This makes the images and .md links work when working with both the 1.9 builds and the PR builds.