### PR TITLE
Update styling of code-blocks and notes

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -37,26 +37,42 @@ a {
   font-variant-ligatures: common-ligatures;
 }
 
-pre {
-    margin-bottom: 1.5rem;
-}
 body {
   color: #050E1A; !important
   text-shadow:0 0 5px transparent;
   font-variant-ligatures: common-ligatures;
 }
 
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #ffcb94;
+  margin-bottom: 1.5rem;
+}
 code {
   background-color: #f8f8f8;
+  white-space: nowrap;
 }
 
+pre > code {
+  white-space: pre;
+  border: none;
+}
+
+blockquote {
+	padding-left: 0;
+}
 blockquote, blockquote p {
   line-height: 1.6;
   color: #0296C9;
 }
 
+blockquote p {
+  border-left: 3px solid #0296C9;
+  padding-left: 1rem;
+}
+
 div#buildinfo {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 #multiple {


### PR DESCRIPTION
This updates the styling of code-blocks and "notes" in the documentation

- Inline code is no longer wrapped
- Added back the left-hand border to "notes"

### Before:

<img width="698" alt="before" src="https://cloud.githubusercontent.com/assets/1804568/12523671/3313aad6-c10d-11e5-84e7-a85e38cde205.png">

### After:

<img width="703" alt="after" src="https://cloud.githubusercontent.com/assets/1804568/12523679/436cc502-c10d-11e5-83b9-99ad6c4af2a5.png">

## Other suggestions: color

Not included in this PR, but a possible change to make, is to change the color for inline code examples / definitions. The border we currently use is (imo) a bit "busy" on the eye, so I created two variations below;

### Variation 1

<img width="699" alt="color-variation1" src="https://cloud.githubusercontent.com/assets/1804568/12523741/84bada80-c10d-11e5-94d5-76cc9b58b6e7.png">

### Variation 2

<img width="707" alt="color-variation2" src="https://cloud.githubusercontent.com/assets/1804568/12523740/84a2d584-c10d-11e5-8b63-73a2b2c4649b.png">

## Other suggestions: font-size

Finally, I think the font size of the code (-blocks) can be made *slightly* smaller, so that inline code more closely matches the size of the body-text, and we can fit a tiny bit more code in our example blocks.

With this change, it will look like this (note to self: `code: 0.95rem`, `pre > code: 0.8rem`):

<img width="706" alt="smaller-font" src="https://cloud.githubusercontent.com/assets/1804568/12523817/00bec81c-c10e-11e5-8e46-cf7e52a087cc.png">


