### PR TITLE
Modified footer margin and padding

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -72,7 +72,7 @@ blockquote p {
 }
 
 div#buildinfo {
-  visibility: hidden;
+  display: none;
 }
 
 #multiple {
@@ -81,14 +81,14 @@ div#buildinfo {
 
 .main-footer {
   width: 100%;
-  height: 250px;
   position: absolute;
   bottom: 0;
   left: 0;
+  margin-top: 2rem;
 }
 
 #docs {
-  margin-bottom: 280px;
+  margin-bottom: 8rem;
 }
 
 .off-canvas-wrap {


### PR DESCRIPTION
 - Increased top margin on footer to prevent it from overlapping the
   left tree navigation menu

 - Used display:none for hiding the build information.  This was causing
   a large amount of padding that meant the footer was large on small screen
   devices.

Before:
<img width="1621" alt="screen shot 2016-02-02 at 23 28 39" src="https://cloud.githubusercontent.com/assets/9422816/12768919/64f3741c-ca0b-11e5-9bbb-3ed80e5fe9a3.png">

<img width="297" alt="screen shot 2016-02-03 at 00 17 39" src="https://cloud.githubusercontent.com/assets/9422816/12768947/99e7dc94-ca0b-11e5-86d3-9f29c1d2d88b.png">

After:
<img width="1215" alt="screen shot 2016-02-03 at 00 11 45" src="https://cloud.githubusercontent.com/assets/9422816/12768928/729013f0-ca0b-11e5-993e-b3983afb87c5.png">

<img width="302" alt="screen shot 2016-02-03 at 00 21 15" src="https://cloud.githubusercontent.com/assets/9422816/12769027/1df46bb0-ca0c-11e5-89d7-dada81a4143a.png">

Signed-off-by: Lynda O'Leary <lyndaoleary29@gmail.com>