### PR TITLE
Hugo changed the config key, now it's this.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ verbose = true
 [blackfriday]
   fractions = false
   smartDashes = false
-  plainIdAnchors = true
+  plainIDAnchors = true
   sourceRelativeLinksEval = true
 
 # Menu configuration should come last in this file;


### PR DESCRIPTION
This fixes hash urls which contain ids: https://gohugo.io/overview/configuration/#configure-blackfriday-rendering