### PR TITLE
Remove the cloud api menu - it will be dealt with from its product repo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,16 +26,6 @@ verbose = true
 	weight = 8
 
 #
-# Component projects is a menu for Registry/Notary etc.
-#
-[[menu.main]]
-	name = "API reference"
-	parent = "docker-cloud"
-  url = "/apidocs/docker-cloud/"
-	weight = 90
-
-
-#
 # About
 #
 [[menu.main]]


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

do not merge until the other one is merged :)