### PR TITLE
removing cloud reference from the config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,11 +16,7 @@ verbose = true
 # Menu configuration should come last in this file;
 # leave at least one blank line at the end
 #
-[[menu.main]]		
-   name = "API reference"
-   parent = "docker-cloud"
-   url = "/apidocs/docker-cloud/"
-   weight = 90
+
 #
 # Component projects is a menu for Registry/Notary etc.
 #


### PR DESCRIPTION
Reverts docker/docs-base#223

merge https://github.com/docker/cloud-docs/pull/48 first.