### PR TITLE
Makefile targets for docs development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/
 
 node_modules
 bower_components
+devdeps

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ test: docs-build
 	docker run --rm "$(DOCKER_DOCS_IMAGE)"
 
 # clone required repos under devdeps folder
+# WARNING: Please note that flickerbox-test is a branch on a private fork, where the docs redesign is compatible with.
+#          This is a temporary situation and all the code will eventually merged to the master branch.
+#          Once the flickerbox-test is merged to master, the line in dev-deps-docker should be:
+#          @(if test -d devdeps/docker; then echo devdeps/docker found, skipping; else mkdir -p devdeps/docker; git clone https://github.com/docker/docker.git devdeps/docker; fi)
 dev-deps-docker:
 	@(if test -d devdeps/docker; then echo devdeps/docker found, skipping; else mkdir -p devdeps/docker; git clone -b flickerbox-test https://github.com/moxiegirl/docker.git devdeps/docker; fi)
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,28 @@ shell:
 test: docs-build
 	docker run --rm "$(DOCKER_DOCS_IMAGE)"
 
+# clone required repos under devdeps folder
+dev-deps-docker:
+	@(if test -d devdeps/docker; then echo devdeps/docker found, skipping; else mkdir -p devdeps/docker; git clone -b flickerbox-test https://github.com/moxiegirl/docker.git devdeps/docker; fi)
+
+# install dependencies for static
+dev-deps-static:
+	@(cd themes/docker-docs/static/ && npm install -g grunt-cli && npm install && bower install)
+
+# build static assets
+dev-build-static:
+	grunt build --gruntfile themes/docker-docs/static/Gruntfile.js
+
+# build static assets and docs image
+dev-build: dev-build-static docs-build
+
+# dev-build and run docs for docker engine
+dev-run: dev-build
+	make -f devdeps/docker/docs/Makefile
+
+# all dev tasks. Intended to be run only once at the beginning
+dev-all: dev-deps-docker dev-deps-static dev-run
+
 docs-build:
 #	( git remote | grep -v upstream ) || git diff --name-status upstream/release..upstream/docs ./ > ./changed-files
 #	echo "$(GIT_BRANCH)" > GIT_BRANCH
@@ -68,4 +90,3 @@ markdownlint:
 
 htmllint:
 		docker exec -it docker-docs-tools /usr/local/bin/linkcheck http://127.0.0.1:8000
-

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,56 @@
+This document describes how to set up a development environment for docs-base. The docker/docs-base repository defines the visual theme for Docker’s product documentation. To change the look and feel of the documentation, a developer must change the rendering mechanism defined in docs-base.
+
+###Dependencies
+To run the setup for docs developer, below requirements are needed.  
+
+#####NPM
+	http://blog.npmjs.org/post/85484771375/how-to-install-npm  
+
+#####Bower  
+	npm install -g bower  
+
+#####Grunt  
+	npm install -g grunt-cli  
+
+###First time setup
+Clone the flickerbox branch of the docs-base repo to your local machine. **Please note that flickerbox is a private branch where the docs redesign is currently developed. This is a temporary situation and all the code will eventually merged to the master branch. Please update this documentation once it's completed.**
+
+	git clone -b flickerbox https://github.com/docker/docs-base.git
+
+Run the makefile target from the docs-base root  for the first time setup.
+
+	make dev-all
+
+###Changing and testing the code
+There are two folders that you will most likely need to change the code. After any change in these places you can run `make dev-run` to pick up the changed code and rebuild/restart the local docs site with them.  
+After running `make dev-run` you should be seeing the local docs site running on port 8000 of your docker machine (e.g. http://192.168.99.100:8000/). This site has the documentation from docker repository cloned under /devdeps folder with the style or layout changes made under two locations below. Please note that you may have a different IP for your docker machine VM. Double-check that before opening the site.
+
+####themes/docker-docs/layouts
+This is where the docs home page and navigation menu layouts are stored. You can look under each product folder to see the specific renderings. For any template starting with partial keyword, check under docs-base/layouts/partials folder.
+####docs-base/themes/docker-docs/static
+This is where all the static CSS/JS resources used to style the docs site can be found. This folder is by itself a standalone project where you can build using Grunt. All the source files are under /src folder and any changes made there is built/copied to /dist folder.
+
+###Makefile targets for local development
+
+#####make dev-deps-docker
+Clones required repos under devdeps folder.
+
+#####make dev-deps-static
+Installs npm and bower dependencies for static assets under themes/docker-docs/static
+
+#####make dev-build-static
+Builds all sources under themes/docker-docs/static/src to themes/docker-docs/static/dist
+
+#####make dev-build
+Runs dev-build-static and builds image from docs-base/Dockerfile.
+
+#####make dev-run
+Runs dev-build and starts the docker engine docs site.
+
+#####make dev-all
+Runs dev-deps-docker dev-deps-static dev-run to build everything from scratch. This target is intended to be run for the first time setup.
+
+
+Testing the code
+
+Unit Testing with Hugo


### PR DESCRIPTION
@moxiegirl 
I wanted to add some helper targets to make the development setup on line command. After these additions you can run `make dev-all` from docs-base root and it will clone a copy of docker flickerbox-test under /devdeps/docker folder where it can further build/run the container under docker/docs. Whenever you have a style change under themes/docker-docs/static, you can run make-run and it will do the magic for you. There are also other sub-targets (dev-deps, dev-build and dev-build-static) which can be used individually.
I'm also planning to write a wiki page explaining these steps. Probably later today.