### PR TITLE
update to a new Hugo pre-release build with more fixes in it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install awscli==1.4.4 pyopenssl==0.12
 #	&& mv /usr/local/bin/hugo_${HUGO_VERSION}_linux_amd64 /usr/local/bin/hugo
 
 # Using a pre-build of hugo 0.16
-ENV HUGO_VERSION 0.16-pre1
+ENV HUGO_VERSION 0.16-pre3
 RUN curl -sSL -o /usr/local/bin/hugo https://github.com/docker/hugo/releases/download/${HUGO_VERSION}/hugo
 RUN chmod 755 /usr/local/bin/hugo
 RUN /usr/local/bin/hugo version

--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,7 @@ verbose = true
   smartDashes = false
   plainIDAnchors = true
   sourceRelativeLinksEval = true
+  sourceRelativeLinksProjectFolder = "/docs"
 
 # Menu configuration should come last in this file;
 # leave at least one blank line at the end


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

replaces #226 

also need to set the new blackfriday sourceRelativeLinksProjectFolder setting that was added in this version of Hugo.


you need to remove the `--pull` from the `docs.docker.com` `Makefile` if you change the `Dockerfile` to use the image you've built locally from this branch.