### PR TITLE
Add a base image file that can be used for testing

### DIFF
--- a/oss-projects/Dockerfile
+++ b/oss-projects/Dockerfile
@@ -1,0 +1,13 @@
+FROM docs/base:latest
+MAINTAINER Sven Dowideit <SvenDowideit@home.org.au> @SvenDowideit
+
+# we use subversion to avoid needing a GitHubToken for API calls.
+RUN svn checkout https://github.com/docker/compose/trunk/docs /docs/content/compose
+RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content/registry
+RUN svn checkout https://github.com/docker/docker/trunk/docs /docs/content/engine
+RUN svn checkout https://github.com/docker/kitematic/trunk/docs /docs/content/kitematic
+RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/machine
+RUN svn checkout https://github.com/docker/notary/trunk/docs /docs/content/notary
+RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content/opensource
+RUN svn checkout https://github.com/docker/swarm/trunk/docs /docs/content/swarm
+RUN svn checkout https://github.com/docker/toolbox/trunk/docs /docs/content/toolbox

--- a/oss-projects/README.md
+++ b/oss-projects/README.md
@@ -1,0 +1,18 @@
+# OSS projects base image
+
+This image adds the OSS project's documentation to facilitate faster documentation testing,
+both by the writers, and the Jenkins jobs.
+
+To use this image to build your project's documentation, add a `docs/Dockerfile` that looks
+like the following example from the `docker/machine` project.
+
+```
+FROM docs/base:oss
+
+ENV PROJECT=machine
+
+# To get the git info for this repo
+COPY . /src
+RUN rm -r /docs/content/$PROJECT/
+COPY . /docs/content/$PROJECT/
+```


### PR DESCRIPTION
We've been using `svn checkout` for every writer and Jenkins job run of `make docs` to ensure that we're testing with the latest documentation from each repo.

This is now intermittently causing build failures due to the load we're putting on github, instead, I'll get Docker Hub to re-build a `docs/base:oss` image regularly, and then will change all the oss projects to use that image.

This increases the (small) probability of false problem reports by the checkers, or by writers, but in most cases should give everyone a faster docs experience.