### PR TITLE
disable ligatures inside code blocks

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -43,13 +43,16 @@ body {
   font-variant-ligatures: common-ligatures;
 }
 
-pre {
+pre, code {
   background-color: #f8f8f8;
+  font-variant-ligatures: no-common-ligatures;
+}
+
+pre {
   border: 1px solid #ffcb94;
   margin-bottom: 1.5rem;
 }
 code {
-  background-color: #f8f8f8;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
ligatures are a nice addition for regular text, but don't make a lot of sense for code samples.

this change disables ligatures for code blocks, to prevent (e.g.) 'fi' in '--filter' being replaced by a ligature.

screenshots below are made on iOS, which now supports "ligatures", so making this apparent 

before:
![before](https://cloud.githubusercontent.com/assets/1804568/14913345/b48127c8-0e02-11e6-808a-472c63445b0b.jpg)

after:
![after](https://cloud.githubusercontent.com/assets/1804568/14913348/b9ca0786-0e02-11e6-8f7d-4253efbb0387.jpg)