### PR TITLE
Copy the generic microsite layout to docs-base from the cluster-docs …

### DIFF
--- a/layouts/microsite/single.html
+++ b/layouts/microsite/single.html
@@ -1,0 +1,15 @@
+{{ partial "header.html" . }}
+<div id="docs" class="row">
+    <div class="large-3 columns" class="tutmenu">
+      {{ partial "microsite-navbar.html" . }}
+    </div>
+    <div class="large-9 columns">
+      <section id="main">
+        <article id="content" class="tutorial">
+          <div class="microsite" >
+              {{ .Content }}
+          </div>
+    </div>
+</div>
+{{ partial "container-footer.html" . }}
+{{ partial "footer.html" . }}

--- a/layouts/partials/microsite-navbar.html
+++ b/layouts/partials/microsite-navbar.html
@@ -1,0 +1,55 @@
+<section id="multiple" class="tutmenu" data-accordion-group>
+  {{ $currentNode := . }}
+  {{ $menu := index ( index $.Site.Menus  ($.Params.menuname) ) }}{{ $currentNode := . }}{{ range $menu }}
+    <section data-accordion>
+      {{ if .HasChildren }}
+        <article data-accordion>
+          <button data-control>{{ .Pre }} {{ .Name }}</button>
+          <div data-content>
+            {{ range .Children }}
+              {{if .HasChildren}}
+                <article data-accordion>
+                  <button data-control>{{ .Pre }} {{ .Name }}</button>
+                  <div data-content>
+                    {{ range .Children }}
+                      {{if .HasChildren}}
+                        <article data-accordion>
+                          <button data-control>{{ .Pre }} {{ .Name }}</button>
+                          <div data-content>
+                            {{ range .Children }}
+                                <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent $.Params.menuname . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+                            {{ end }}
+                           </div>
+                         </article> 
+                      {{else}}
+                        <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent $.Params.menuname . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+                      {{end}}
+                      
+                    {{end}}
+                  </div>
+                </article>
+              {{else}}
+                <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent $.Params.menuname . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+              {{end}}
+            {{end}}
+          </div>
+        </article>
+      {{else}}
+        <a data-link href="{{ .URL }}" class="{{if $currentNode.IsMenuCurrent $.Params.menuname . }} active{{end}}">{{ .Pre }} {{ .Name }}</a>
+      {{end}} 
+    </section>
+  {{end}}
+</section>
+
+<script>
+$(document).ready(function () {
+  var $activeLink = $('#multiple [data-link].active');
+  var $accordions = $activeLink.parents('article[data-accordion]');
+  $($accordions.get().reverse()).each(function (index, accordion) {
+    var $accordion = $(accordion);
+    var $content = $accordion.find('[data-content]');
+    $accordion.addClass('open');
+    $content.css({'max-height': '100%'});
+  });
+});
+</script>


### PR DESCRIPTION
…repo, in preparation for using it in the tutorials repo too

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

@thaJeztah @sfsmithcha 

These files will replace the `mac`, `linux` and `windows` layouts, and can be reused for any menu microsite.