### PR TITLE
Add a menu layout type to redirect to the dir's index.html

### DIFF
--- a/content/test/index.md
+++ b/content/test/index.md
@@ -1,0 +1,10 @@
++++
+title = "Test index page"
+description = "test index page"
+keywords = ["docker, documentation, about, technology, understanding,  release"]
+[menu.main]
+parent = "mn_test"
++++
+
+# test index page
+

--- a/content/test/menu.md
+++ b/content/test/menu.md
@@ -1,0 +1,13 @@
++++
+title = "Test menu"
+description = "test menu"
+keywords = ["docker, documentation, about, technology, understanding,  release"]
+type = "menu"
+[menu.main]
+identifier = "mn_test"
+weight = 9
++++
+
+# Menu topic
+
+If you can view this content, please raise a bug report.

--- a/layouts/menu/single.html
+++ b/layouts/menu/single.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>redirect to index</title>
+    <link rel="canonical" href="../"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="refresh" content="0; url=../"/>
+  </head>
+</html>
+


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

@sanscontext @londoncalling @sfsmithcha @joaofnfernandes 

This is the bare minimum `menu.md` that you can use to define a menu item. the `type="menu"` will mean that anyone navigating to that page will be sent to the index for that dir.

note that you can call the file anything else - if your IA needs an `menu.md` (or we could use something even more obscure like `zzz_menu.md` :)