### PR TITLE
update linkcheck to not parse js/css and respect 404.html's baseUrl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -sSL -o /usr/local/bin/hugo https://github.com/docker/hugo/releases/dow
 RUN curl -sSL -o /usr/local/bin/markdownlint https://github.com/docker/markdownlint/releases/download/v0.9.5/markdownlint \
  && chmod 755 /usr/local/bin/markdownlint
 
-RUN curl -sSL -o /usr/local/bin/linkcheck https://github.com/docker/linkcheck/releases/download/v0.3/linkcheck \
+RUN curl -sSL -o /usr/local/bin/linkcheck https://github.com/docker/linkcheck/releases/download/v0.4/linkcheck \
  && chmod 755 /usr/local/bin/linkcheck
 
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>