### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/static/highlight/CHANGES.md
+++ b/static/highlight/CHANGES.md
@@ -46,7 +46,7 @@ Other notable changes:
 [webworkers]: https://github.com/isagalaev/highlight.js#web-workers
 [Jeremy Hull]: https://github.com/sourrust
 [#348]: https://github.com/isagalaev/highlight.js/issues/348
-[sg]: http://highlightjs.readthedocs.org/en/latest/style-guide.html
+[sg]: https://highlightjs.readthedocs.io/en/latest/style-guide.html
 [issues]: https://github.com/isagalaev/highlight.js/issues
 [Nebuleon Fumika]: https://github.com/Nebuleon
 [prince]: https://github.com/prince-0203
@@ -314,7 +314,7 @@ New languages in this release:
 - *ERB* (Ruby in HTML) by [Lucas Mazza][]
 - *Roboconf* by [Vincent Zurczak][]
 
-[b]: http://highlightjs.readthedocs.org/en/latest/building-testing.html
+[b]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
 [Jeremy Hull]: https://github.com/sourrust
 [ik]: https://twitter.com/IvanKleshnin/status/514041599484231680
 [Max Mikhailov]: https://github.com/seven-phases-max
@@ -444,7 +444,7 @@ Other improvements:
 - Various improvements to Objective-C definition by [Matt Diephouse][].
 - Fixed highlighting of generics in Java.
 
-[ll]: http://highlightjs.readthedocs.org/en/latest/api.html#listlanguages
+[ll]: https://highlightjs.readthedocs.io/en/latest/api.html#listlanguages
 [Sindre Sorhus]: https://github.com/sindresorhus
 [Heiko August]: https://github.com/auge8472
 [Nikolay Lisienko]: https://github.com/neor-ru
@@ -537,10 +537,10 @@ Miscellaneous improvements:
 - Big overhaul of relevance counting for a number of languages. Please do report
   bugs about mis-detection of non-trivial code snippets!
 
-[API reference]: http://highlightjs.readthedocs.org/en/latest/api.html
+[API reference]: https://highlightjs.readthedocs.io/en/latest/api.html
 
-[cr]: http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
-[api docs]: http://highlightjs.readthedocs.org/en/latest/api.html
+[cr]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
+[api docs]: https://highlightjs.readthedocs.io/en/latest/api.html
 [variants]: https://groups.google.com/d/topic/highlightjs/VoGC9-1p5vk/discussion
 [beginKeywords]: https://github.com/isagalaev/highlight.js/commit/6c7fdea002eb3949577a85b3f7930137c7c3038d
 [php-html]: https://twitter.com/highlightjs/status/408890903017689088
@@ -694,7 +694,7 @@ Other notable changes:
 - Also Oleg Efimov did a great job of moving all the docs for language and style
   developers and contributors from the old wiki under the source code in the
   "docs" directory. Now these docs are nicely presented at
-  <http://highlightjs.readthedocs.org/>.
+  <https://highlightjs.readthedocs.io/>.
 
 [ng]: https://github.com/nathan11g
 [dd]: https://github.com/drdrang

--- a/static/highlight/README.md
+++ b/static/highlight/README.md
@@ -120,15 +120,15 @@ for details.
 The official site for the library is at <https://highlightjs.org/>.
 
 Further in-depth documentation for the API and other topics is at
-<http://highlightjs.readthedocs.org/>.
+<https://highlightjs.readthedocs.io/>.
 
 Authors and contributors are listed in the [AUTHORS.en.txt][8] file.
 
-[1]: http://highlightjs.readthedocs.org/en/latest/api.html#inithighlightingonload
-[2]: http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
-[3]: http://highlightjs.readthedocs.org/en/latest/api.html#highlightblock-block
-[4]: http://highlightjs.readthedocs.org/en/latest/api.html#configure-options
+[1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[2]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
+[3]: https://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
+[4]: https://highlightjs.readthedocs.io/en/latest/api.html#configure-options
 [5]: https://highlightjs.org/download/
-[6]: http://highlightjs.readthedocs.org/en/latest/building-testing.html
+[6]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
 [7]: https://github.com/isagalaev/highlight.js/blob/master/LICENSE
 [8]: https://github.com/isagalaev/highlight.js/blob/master/AUTHORS.en.txt

--- a/static/highlight/README.ru.md
+++ b/static/highlight/README.ru.md
@@ -114,15 +114,15 @@ Highlight.js распространяется под лицензией BSD. П�
 Официальный сайт билиотеки расположен по адресу <https://highlightjs.org/>.
 
 Более подробная документация по API и другим темам расположена на
-<http://highlightjs.readthedocs.org/>.
+<https://highlightjs.readthedocs.io/>.
 
 Авторы и контрибьютора перечислена в файле [AUTHORS.ru.txt][9] file.
 
-[1]: http://highlightjs.readthedocs.org/en/latest/api.html#inithighlightingonload
-[2]: http://highlightjs.readthedocs.org/en/latest/api.html#highlightblock-block
-[3]: http://highlightjs.readthedocs.org/en/latest/api.html#configure-options
+[1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[2]: https://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
+[3]: https://highlightjs.readthedocs.io/en/latest/api.html#configure-options
 [4]: https://highlightjs.org/download/
-[5]: http://highlightjs.readthedocs.org/en/latest/building-testing.html
-[8]: http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
+[5]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
+[8]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
 [9]: https://github.com/isagalaev/highlight.js/blob/master/AUTHORS.ru.txt
 [10]: https://github.com/isagalaev/highlight.js/blob/master/LICENSE


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.