### PR TITLE
Add anchor-links

### DIFF
--- a/themes/docker-2016/layouts/partials/footer.html
+++ b/themes/docker-2016/layouts/partials/footer.html
@@ -73,7 +73,9 @@
   <!-- doc menu -->
 	<script async src="/menu.js"></script>
 	<script async src="/assets/js/app.js"></script>
-		<!-- Google Tag Manager --> 
+	<script async src="/assets/js/anchorlinks.js"></script>
+
+	<!-- Google Tag Manager --> 
 	<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WLGFZV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/themes/docker-2016/static/assets/js/anchorlinks.js
+++ b/themes/docker-2016/static/assets/js/anchorlinks.js
@@ -1,0 +1,12 @@
+(function(d) {
+	"use strict";
+	var hs = d.getElementById("DocumentationText").querySelectorAll("H1, H2, H3"), h;
+
+	for (var i = 0; i < hs.length; i++) {
+		h = hs[i];
+		if (h.id != null && h.id.length > 0) {
+			h.insertAdjacentHTML('beforeend', '<a href="#' + h.id + '" class="anchorLink">&para;</a>')
+		}
+	}
+
+})(document);

--- a/themes/docker-2016/static/documentation.css
+++ b/themes/docker-2016/static/documentation.css
@@ -69,6 +69,18 @@
 #DocumentationText table {
     margin: 1.25rem 0;
 }
+
+a.anchorLink {
+    margin-left: 5px;
+    visibility: hidden;
+}
+h1:hover > a.anchorLink,
+h2:hover > a.anchorLink,
+h3:hover > a.anchorLink
+{
+    visibility: visible;
+}
+
 /* ========== Start sidebarnav ========== */
 div.docsidebarnav_section.affix {
     position: fixed;


### PR DESCRIPTION
Adds clickable anchor links to headers (h1..h3) for
easier bookmarking or sharing links to specific
sections of the documentation.

fixes https://github.com/docker/docs-base/issues/98

Anchor-links are only visible on "hover";

<img width="362" alt="screen shot 2016-06-24 at 17 47 10" src="https://cloud.githubusercontent.com/assets/1804568/16353751/49739a34-3a34-11e6-8ad3-2c0d7f95e972.png">
