### PR TITLE
change tables to be full-width

### DIFF
--- a/themes/docker-2016/static/documentation.css
+++ b/themes/docker-2016/static/documentation.css
@@ -68,6 +68,7 @@
 }
 #DocumentationText table {
     margin: 1.25rem 0;
+    width: 100%;
 }
 
 a.anchorLink {


### PR DESCRIPTION
change tables to be full-width at all times
for a more consistent layout. It's not perfect (yet),
because column-widths are still "auto", but overall
this gives a cleaner layout.

before and after below:

<img width="987" alt="screen shot 2016-06-30 at 15 43 26" src="https://cloud.githubusercontent.com/assets/1804568/16506794/ca6fe300-3ed9-11e6-93d2-2cbcf64b0176.png">

<img width="1314" alt="screen shot 2016-06-30 at 15 43 55" src="https://cloud.githubusercontent.com/assets/1804568/16506796/cfd42d42-3ed9-11e6-95ef-5587e88bda3a.png">
