### PR TITLE
Use absolute url for newsletter redirect

### DIFF
--- a/themes/docker-2016/layouts/partials/footer.html
+++ b/themes/docker-2016/layouts/partials/footer.html
@@ -5,20 +5,20 @@
 				<div class="col-xs-12 col-sm-5 col-md-5 col-sm-push-3 col-md-push-3">
 					<h6>Connect</h6>
 					<p>Subscribe to our newsletter</p>
-					<div class=" newsletter"> 
+					<div class=" newsletter">
 						<script src="//app-sj05.marketo.com/js/forms2/js/forms2.min.js"></script>
 						<form id="mktoForm_1038"></form>
 						<script>
 							MktoForms2.loadForm("//app-sj05.marketo.com", "929-FJL-178", 1038, function(form) {
 								form.onSuccess(function(values, followUpUrl) {
-									location.href = "/thank-you-subscribing-docker-newsletter";
+									location.href = "https://www.docker.com/thank-you-subscribing-docker-weekly";
 									return false;
 								});
 							});
 							MktoForms2.whenReady(function(form){
 							/*	$('#mktoForm_1038 #Email').attr('placeholder', 'Enter your email'); */
 							});
-						</script> 
+						</script>
 					</div>
 					<ul class="social-icons">
 						<li class="facebook"><a target="_blank" href="https://www.facebook.com/docker.run">facebook</a></li>
@@ -60,7 +60,7 @@
 		</nav>
 	</div>
 	<div class="col-xs-12 col-sm-12 col-md-7 col-md-pull-5">
-		<p>Build, Ship, Run. An open platform for distributed applications for developers and sysadmins</p> 
+		<p>Build, Ship, Run. An open platform for distributed applications for developers and sysadmins</p>
 	</div>
 </div>
 			</div>
@@ -81,7 +81,7 @@
 	<script async src="/assets/js/app.js"></script>
 	<script async src="/assets/js/anchorlinks.js"></script>
 
-	<!-- Google Tag Manager --> 
+	<!-- Google Tag Manager -->
 	<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WLGFZV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Whilst on subdomains *.docker.com the relative URL causes a 404 page to be displayed, changing to an absolute URL to the correct page