### PR TITLE
Various menu fixes

### DIFF
--- a/themes/docker-2016/layouts/_default/single.html
+++ b/themes/docker-2016/layouts/_default/single.html
@@ -19,7 +19,7 @@
                 <section class="section" id="TableOfContentsSection">
 		    <span class="title_section">
   <form class="search-form form-inline ng-pristine ng-valid" action="/search/">
-    <input class="search-field form-control" id="st-search-input" value="" name="q" placeholder="Search the Documentation" type="search">
+    <input class="search-field form-control" id="st-search-input" value="" name="q" placeholder="Search the docs" type="search">
     <button type="submit" class="search-submit btn btn-default">Search</button>
   </form>
 		    </span>

--- a/themes/docker-2016/layouts/partials/navbar-inner.html
+++ b/themes/docker-2016/layouts/partials/navbar-inner.html
@@ -3,8 +3,7 @@
 {{ range .menu }}
 {{ if .HasChildren }}
     <li class="leaf {{ if $thispage.HasMenuCurrent "main" . }} active{{end}} {{ if $thispage.HasMenuCurrent "main" . }} menu-open {{else}} menu-closed {{end}} ">
-        <a href="" class="expand-menu {{ if $thispage.HasMenuCurrent "main" . }} active{{end}}"> {{ .Pre }} {{ .Name }} <span class="menu-icon" aria-hidden="true"></span>
- </a>
+        <a href="" class="expand-menu {{ if $thispage.HasMenuCurrent "main" . }} active{{end}}"><span class="menu-icon" aria-hidden="true"></span> {{ .Pre }} {{ .Name }}</a>
         {{ partial "navbar-inner.html" (dict "menu" .Children "thispage" $thispage) }}
     </li>
 {{ else }}

--- a/themes/docker-2016/static/documentation.css
+++ b/themes/docker-2016/static/documentation.css
@@ -222,7 +222,7 @@ div.docsidebarnav_section.affix ul {
   font-size: 14px;
   font-style: normal;
   margin: 0;
-  padding: 10px 0 10px 15px;
+  padding: 10px 15px;
   display: block;
   line-height: 15px;
 }
@@ -243,11 +243,12 @@ div.docsidebarnav_section.affix ul {
     width: 100%;
     text-align: left;
     overflow: hidden;
-    margin-left: 0.30rem;
+    margin-left: 0;
+    padding-left: 0.30rem;
     font-size: 14px;
 }
 #TableOfContentsSection #TableOfContents > ul {
-  margin-left: 0;
+  padding-left: 0;
 }
 .advisory {
 color: #F04124;

--- a/themes/docker-2016/static/documentation.css
+++ b/themes/docker-2016/static/documentation.css
@@ -250,6 +250,17 @@ div.docsidebarnav_section.affix ul {
 #TableOfContentsSection #TableOfContents > ul {
   padding-left: 0;
 }
+
+/* HACK: Don't display current page title in TOC. */
+/* This removes one level of hierarchy and makes it a bit more compact. */
+#TableOfContentsSection #TableOfContents > ul > li > a {
+  display: none;
+}
+
+#TableOfContentsSection #TableOfContents > ul > li > ul {
+  padding-left: 0;
+}
+
 .advisory {
 color: #F04124;
     margin: -20px -20px 20px -20px;

--- a/themes/docker-2016/static/documentation.css
+++ b/themes/docker-2016/static/documentation.css
@@ -246,8 +246,8 @@ div.docsidebarnav_section.affix ul {
     margin-left: 0.30rem;
     font-size: 14px;
 }
-​​nav#TableOfContents > ul {
-  margin-left: 0 !important;
+#TableOfContentsSection #TableOfContents > ul {
+  margin-left: 0;
 }
 .advisory {
 color: #F04124;


### PR DESCRIPTION
1. Cleaned up left hand menu by fixing the arrow getting pushed off by long text.

    - Before:

       ![screenshot 2016-07-29 11 53 47](https://cloud.githubusercontent.com/assets/40906/17247207/97f7762e-5589-11e6-9900-64850971eb3e.png)

    - After:

       ![screenshot 2016-07-29 11 53 56](https://cloud.githubusercontent.com/assets/40906/17247215/a170f356-5589-11e6-9435-a9cb9f70d3bf.png)

2. Removed the top-level link in the table of contents, stopped the links from falling off the right hand side of the page, and removed some unnecessary padding.

    - Before:

       ![screenshot 2016-07-29 11 59 50](https://cloud.githubusercontent.com/assets/40906/17247271/072aacbe-558a-11e6-9084-919d0eb0a2f6.png)

    - After:

       ![screenshot 2016-07-29 12 07 40](https://cloud.githubusercontent.com/assets/40906/17247279/13486798-558a-11e6-8174-0d2274d4415f.png)