### PR TITLE
re-enable advisory banner for Docker Swarm

### DIFF
--- a/data/advisories.toml
+++ b/data/advisories.toml
@@ -21,6 +21,6 @@ engine = "This site contains documentation for the v1.12 release candidate versi
 # URL based advisories
 # any URL that begins with "/engine/" will get the "engine" advisory
 # will be over-ridden by the `advisory` frontmatter in the topic
-# [paths]
+ [paths]
 # "/engine/" = "engine"
-# "/swarm/" = "swarm"
+ "/swarm/" = "swarm"


### PR DESCRIPTION
re-enables the advisory for component project "Docker Swarm" docs to help reduce confusion with "swarm mode" in Engine
Signed-off-by: Charles Smith <charles.smith@docker.com>